### PR TITLE
Update README and IBroker interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Breaking changes for version 1.0.4 and higher
 #### Commands
 * IBroker
 * Broker
-* IRqstMessage
 * IHandler
 * IAsyncHandler
 
@@ -34,7 +33,7 @@ Call
 ```cs
 public class TestController:Controller
 {
-	private ICommandBroker _broker;
+	private IBroker _broker;
 
 	public TestController(IBroker broker)
 	{
@@ -63,7 +62,7 @@ public class TestController:Controller
 
 ### Creating a Command Handler
 * A Handler is used for gettting, inserting, updating, or deleting data from your database.
-* The DomainEventPublisher is used to publish messages accross your domain.
+* The DomainEventPublisher is used to publish messages across your domain.
 * Ideally commands should be encapsulated and should not call other commands.
 * If you need to query for data then it should be part of the command encapsulating the functionality.
 ```cs
@@ -75,6 +74,7 @@ public class TestController:Controller
         {
             _publisher = publisher;
         }
+
         public async Task<CommandResponse<string>> Execute(CreateWidgetMessage message)
         {
             var response = Guid.NewGuid().ToString();

--- a/src/CommandQuery.Framing/IBroker.cs
+++ b/src/CommandQuery.Framing/IBroker.cs
@@ -5,7 +5,7 @@ namespace CommandQuery.Framing
 {
     public interface IBroker
     {
-        Task<TResponse> HandleAsync<TRequest, TResponse>(TRequest message, CancellationToken cancellationToken) where TRequest : IMessage;
+        Task<TResponse> HandleAsync<TRequest, TResponse>(TRequest message, CancellationToken cancellationToken = default) where TRequest : IMessage;
         TResponse Handle<TRequest, TResponse>(TRequest message) where TRequest : IMessage;
     }
 }


### PR DESCRIPTION
- Removed `IRqstMessage` from the "Objects" section in README.
- Replaced `ICommandBroker` with `IBroker` in example code.
- Fixed typo ("accross" -> "across") in `DomainEventPublisher` docs.
- Made `CancellationToken` optional in `IBroker.HandleAsync`.