### PR TITLE
Adds domain event pipeline support

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,151 @@
+name: Build and Publish NuGet
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    tags:
+      - 'v*.*.*'
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '9.0.x'
+  PROJECT_PATH: 'src/CommandQuery.Framing/CommandQuery.Framing.csproj'
+  NUGET_OUTPUT: 'src/CommandQuery.Framing/nuget'
+
+jobs:
+  build-and-test:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Required for versioning
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+    
+    - name: Restore dependencies
+      run: dotnet restore
+    
+    - name: Build solution
+      run: dotnet build --configuration Release --no-restore
+    
+    - name: Run tests
+      run: dotnet test --configuration Release --no-build --verbosity normal
+    
+    - name: Determine version
+      id: version
+      run: |
+        if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+          # Use tag version (e.g., v1.0.11 -> 1.0.11)
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "suffix=" >> $GITHUB_OUTPUT
+        else
+          # Read base version from csproj
+          BASE_VERSION=$(grep -oP '<Version>\K[^<]+' ${{ env.PROJECT_PATH }})
+          # Use build number for pre-release versions
+          BUILD_NUMBER=${{ github.run_number }}
+          VERSION="$BASE_VERSION"
+          SUFFIX="ci.$BUILD_NUMBER"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "suffix=$SUFFIX" >> $GITHUB_OUTPUT
+        fi
+        echo "Building version: $VERSION${SUFFIX:+-$SUFFIX}"
+      shell: bash
+    
+    - name: Pack NuGet package
+      run: |
+        if [ -z "${{ steps.version.outputs.suffix }}" ]; then
+          dotnet pack ${{ env.PROJECT_PATH }} \
+            --configuration Release \
+            --no-build \
+            --output ${{ env.NUGET_OUTPUT }} \
+            /p:Version=${{ steps.version.outputs.version }}
+        else
+          dotnet pack ${{ env.PROJECT_PATH }} \
+            --configuration Release \
+            --no-build \
+            --output ${{ env.NUGET_OUTPUT }} \
+            /p:Version=${{ steps.version.outputs.version }} \
+            /p:VersionSuffix=${{ steps.version.outputs.suffix }}
+        fi
+      shell: bash
+    
+    - name: Upload NuGet package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: nuget-package
+        path: ${{ env.NUGET_OUTPUT }}/*.nupkg
+        if-no-files-found: error
+    
+    - name: Upload symbol package artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: symbol-package
+        path: ${{ env.NUGET_OUTPUT }}/*.snupkg
+        if-no-files-found: error
+
+  publish-nuget:
+    name: Publish to NuGet.org
+    needs: build-and-test
+    runs-on: ubuntu-latest
+    environment: production
+    if: github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    
+    steps:
+    - name: Download NuGet package
+      uses: actions/download-artifact@v4
+      with:
+        name: nuget-package
+        path: packages
+    
+    - name: Download symbol package
+      uses: actions/download-artifact@v4
+      with:
+        name: symbol-package
+        path: packages
+    
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+    
+    - name: Publish NuGet package
+      run: |
+        dotnet nuget push packages/*.nupkg \
+          --api-key ${{ secrets.NUGET_API_KEY }} \
+          --source https://api.nuget.org/v3/index.json \
+          --skip-duplicate
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    
+    - name: Publish symbol package
+      run: |
+        dotnet nuget push packages/*.snupkg \
+          --api-key ${{ secrets.NUGET_API_KEY }} \
+          --source https://api.nuget.org/v3/index.json \
+          --skip-duplicate
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+    
+    - name: Create GitHub Release
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          packages/*.nupkg
+          packages/*.snupkg
+        generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/PIPELINE_GUIDE.md
+++ b/PIPELINE_GUIDE.md
@@ -1,0 +1,289 @@
+# Domain Event Pipelines
+
+The CommandQuery.Framing framework now supports **before and after pipelines** for domain events using the `abes.GenericPipeline` library. This allows you to add cross-cutting concerns like logging, validation, authorization, and more around your domain event handlers.
+
+## Features
+
+- **Middleware Pattern**: Apply middleware before and after domain event execution
+- **Pipeline Composition**: Chain multiple middleware in a specific order
+- **DI Integration**: Middleware can use dependency injection
+- **Short-Circuit Support**: Stop pipeline execution based on conditions
+- **Context Sharing**: Share data between middleware via the context
+
+## Quick Start
+
+### 1. Add the Package
+
+The `abes.GenericPipeline` package is already included in CommandQuery.Framing.
+
+### 2. Create Middleware
+
+Create middleware by implementing `IPipelineMiddleware<DomainEventContext<TMessage>>`:
+
+```csharp
+using CommandQuery.Framing;
+using GenericPipeline;
+
+public class LoggingMiddleware<TMessage> : IPipelineMiddleware<DomainEventContext<TMessage>>
+{
+    private readonly ILogger _logger;
+
+    public LoggingMiddleware(ILogger<LoggingMiddleware<TMessage>> logger)
+    {
+        _logger = logger;
+    }
+
+    public async ValueTask InvokeAsync(
+        DomainEventContext<TMessage> context, 
+        PipelineDelegate<DomainEventContext<TMessage>> next)
+    {
+        _logger.LogInformation("Before: {MessageType}", typeof(TMessage).Name);
+        
+        await next(context); // Call next middleware or handler
+        
+        _logger.LogInformation("After: {MessageType}, Success: {Success}", 
+            typeof(TMessage).Name, 
+            context.Success);
+    }
+}
+```
+
+### 3. Register Pipeline in Startup
+
+Configure the pipeline for specific message types:
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddCommandQuery(typeof(Startup).Assembly);
+    
+    // Register middleware
+    services
+        .AddDomainEventMiddleware<LoggingMiddleware<WidgetCreated>>()
+        .AddDomainEventMiddleware<ValidationMiddleware<WidgetCreated>>();
+    
+    // Configure pipeline for WidgetCreated events
+    services.AddDomainEventPipeline<WidgetCreated>(builder =>
+    {
+        builder.Use<ValidationMiddleware<WidgetCreated>>();
+        builder.Use<LoggingMiddleware<WidgetCreated>>();
+    });
+}
+```
+
+### 4. Publish Events
+
+Domain events will now flow through the pipeline:
+
+```csharp
+public class CreateWidget : IAsyncHandler<CreateWidgetMessage, CommandResponse<string>>
+{
+    private readonly IDomainEventPublisher _publisher;
+
+    public CreateWidget(IDomainEventPublisher publisher)
+    {
+        _publisher = publisher;
+    }
+
+    public async Task<CommandResponse<string>> Execute(
+        CreateWidgetMessage message,
+        CancellationToken cancellationToken = default)
+    {
+        var widgetId = Guid.NewGuid().ToString();
+
+        // This will execute through the configured pipeline
+        await _publisher.Publish(
+            new WidgetCreated { Id = widgetId, Name = message.Name }, 
+            cancellationToken);
+
+        return Response.Ok(widgetId);
+    }
+}
+```
+
+## DomainEventContext<TMessage>
+
+The pipeline context provides:
+
+```csharp
+public class DomainEventContext<TMessage> : PipelineContext
+{
+    // The message being published
+    public TMessage Message { get; set; }
+    
+    // Control flow - set to false to short-circuit
+    public bool ShouldContinue { get; set; } = true;
+    
+    // Result information
+    public bool Success { get; set; } = true;
+    public string ErrorMessage { get; set; }
+    public Exception Exception { get; set; }
+    
+    // From PipelineContext:
+    public CancellationToken CancellationToken { get; init; }
+    public IDictionary<string, object> Items { get; } // For sharing data
+}
+```
+
+## Common Middleware Examples
+
+### Validation Middleware
+
+```csharp
+public class ValidationMiddleware<TMessage> : IPipelineMiddleware<DomainEventContext<TMessage>>
+{
+    public async ValueTask InvokeAsync(
+        DomainEventContext<TMessage> context, 
+        PipelineDelegate<DomainEventContext<TMessage>> next)
+    {
+        if (context.Message == null)
+        {
+            context.Success = false;
+            context.ErrorMessage = "Message cannot be null";
+            context.ShouldContinue = false; // Stop the pipeline
+            return;
+        }
+
+        await next(context);
+    }
+}
+```
+
+### Authorization Middleware
+
+```csharp
+public class AuthorizationMiddleware<TMessage> : IPipelineMiddleware<DomainEventContext<TMessage>>
+{
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public AuthorizationMiddleware(IHttpContextAccessor httpContextAccessor)
+    {
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public async ValueTask InvokeAsync(
+        DomainEventContext<TMessage> context, 
+        PipelineDelegate<DomainEventContext<TMessage>> next)
+    {
+        var user = _httpContextAccessor.HttpContext?.User;
+        
+        if (user == null || !user.Identity?.IsAuthenticated == true)
+        {
+            context.Success = false;
+            context.ErrorMessage = "Unauthorized";
+            context.ShouldContinue = false;
+            return;
+        }
+
+        await next(context);
+    }
+}
+```
+
+### Timing Middleware
+
+```csharp
+public class TimingMiddleware<TMessage> : IPipelineMiddleware<DomainEventContext<TMessage>>
+{
+    private readonly ILogger _logger;
+
+    public TimingMiddleware(ILogger<TimingMiddleware<TMessage>> logger)
+    {
+        _logger = logger;
+    }
+
+    public async ValueTask InvokeAsync(
+        DomainEventContext<TMessage> context, 
+        PipelineDelegate<DomainEventContext<TMessage>> next)
+    {
+        var sw = Stopwatch.StartNew();
+        
+        try
+        {
+            await next(context);
+        }
+        finally
+        {
+            sw.Stop();
+            _logger.LogInformation(
+                "Domain event {MessageType} processed in {ElapsedMs}ms",
+                typeof(TMessage).Name,
+                sw.ElapsedMilliseconds);
+        }
+    }
+}
+```
+
+## Middleware Ordering
+
+You can control middleware execution order:
+
+```csharp
+// Using IOrderedMiddleware for coarse ordering
+public class EarlyMiddleware : IPipelineMiddleware<MyContext>, IOrderedMiddleware
+{
+    public int Order => -10; // Lower runs first
+    
+    public async ValueTask InvokeAsync(MyContext context, PipelineDelegate<MyContext> next)
+    {
+        await next(context);
+    }
+}
+
+// Using IRunBefore<T> constraint
+public class ValidationMiddleware : 
+    IPipelineMiddleware<MyContext>, 
+    IRunBefore<LoggingMiddleware> // Runs before logging
+{
+    public async ValueTask InvokeAsync(MyContext context, PipelineDelegate<MyContext> next)
+    {
+        await next(context);
+    }
+}
+
+// Using IRunAfter<T> constraint
+public class CleanupMiddleware : 
+    IPipelineMiddleware<MyContext>, 
+    IRunAfter<LoggingMiddleware> // Runs after logging
+{
+    public async ValueTask InvokeAsync(MyContext context, PipelineDelegate<MyContext> next)
+    {
+        await next(context);
+    }
+}
+```
+
+## Short-Circuiting
+
+Stop the pipeline early by setting `ShouldContinue = false`:
+
+```csharp
+public async ValueTask InvokeAsync(
+    DomainEventContext<TMessage> context, 
+    PipelineDelegate<TMessage> next)
+{
+    if (SomeCondition())
+    {
+        context.ShouldContinue = false;
+        context.ErrorMessage = "Condition not met";
+        return; // Don't call next()
+    }
+
+    await next(context);
+}
+```
+
+## Benefits
+
+✅ **Separation of Concerns**: Keep cross-cutting logic separate from business logic  
+✅ **Reusability**: Write middleware once, use across multiple event types  
+✅ **Testability**: Test middleware independently  
+✅ **Flexibility**: Enable/disable middleware via configuration  
+✅ **Performance Monitoring**: Add timing and metrics easily  
+✅ **Error Handling**: Centralized exception handling  
+
+## See Also
+
+- [abes.GenericPipeline Documentation](https://github.com/tomlazelle/pipeline)
+- [Sample Implementation](sample/Domain/Middleware/)
+- [DomainEventContext API](src/CommandQuery.Framing/DomainEventContext.cs)

--- a/README.md
+++ b/README.md
@@ -1,206 +1,379 @@
-# Command Query Framework
+# CommandQuery.Framing
 
-Breaking changes for version 1.0.4 and higher
-### Objects
-#### Commands
-* IBroker
-* Broker
-* IRqstMessage
-* IHandler
-* IAsyncHandler
+**Current Version:** 1.0.10  
+**Target Framework:** .NET 9.0
 
-#### Domain Event
-* IDomainEvent
-* IDomainEventPublisher
+A lightweight, extensible CQRS (Command Query Responsibility Segregation) framework for .NET that simplifies command, query, and domain event handling with built-in pipeline support.
 
-#### Static Response
-* Response
+## Features
+
+✨ **Simple API** - Single `IBroker` interface for executing commands and queries  
+📦 **Auto-Registration** - Automatic handler discovery via assembly scanning  
+🔄 **Domain Events** - Built-in publisher/subscriber pattern with pipeline middleware  
+🎯 **Type-Safe** - Strongly-typed requests and responses  
+⚡ **Async First** - Full async/await support with `CancellationToken`  
+🔌 **Pipeline Middleware** - Add cross-cutting concerns (logging, validation, etc.) to domain events  
+📝 **Well-Documented** - Comprehensive XML documentation for IntelliSense  
+🧪 **Tested** - Includes test suite and working sample application
+
+## Installation
+
+```bash
+dotnet add package CommandQuery.Framing
+```
+
+## Quick Start
 
 ### Setup
-```cs
+
+Register CommandQuery services in your `Startup.cs` or `Program.cs`:
+
+```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-    /// this will add required interface
-    /// this will also search your assemblies for
-    /// types that can be handled
-    services
-        .AddCommandQuery(<Your assemblies here>);
+    // Automatically discovers and registers all handlers in the assembly
+    services.AddCommandQuery(typeof(Startup).Assembly);
 }
 ```
 
-### Calling a Command or Query
-Inject the IBroker into your class
-Call
-```cs
-public class TestController : Controller
+### Using the Broker
+
+Inject `IBroker` into your controllers or services to execute commands and queries:
+
+```csharp
+[ApiController]
+public class WidgetController : ControllerBase
 {
-	private readonly IBroker _broker;
+    private readonly IBroker _broker;
 
-	public TestController(IBroker broker)
-	{
-		_broker = broker;
-	}
+    public WidgetController(IBroker broker)
+    {
+        _broker = broker;
+    }
 
-    [Route("/widget")]
-    [HttpPost]
+    [HttpPost("widget")]
     public async Task<IActionResult> CreateWidget(
-        Widget request, 
+        [FromBody] CreateWidgetMessage request, 
         CancellationToken cancellationToken)
     {
-        // execute command
-        var result = await _broker.HandleAsync<Widget, CommandResponse<string>>(
+        var result = await _broker.HandleAsync<CreateWidgetMessage, CommandResponse<string>>(
             request, 
             cancellationToken);
 
-        // check command result
-        if(result.Success)
-        {
-            // return success
-            return Ok(result.Data);
-        }
+        return result.Success 
+            ? Ok(result.Data) 
+            : BadRequest(result.Message);
+    }
 
-        // return error
-        return BadRequest(result.Message);
+    [HttpGet("widget/{id}")]
+    public async Task<IActionResult> GetWidget(
+        string id, 
+        CancellationToken cancellationToken)
+    {
+        var widget = await _broker.HandleAsync<GetWidget, Widget>(
+            new GetWidget { Id = id }, 
+            cancellationToken);
+
+        return Ok(widget);
     }
 }
 ```
 
-### Creating a Command Handler
-* A Handler is used for getting, inserting, updating, or deleting data from your database.
-* The DomainEventPublisher is used to publish messages across your domain.
-* Ideally commands should be encapsulated and should not call other commands.
-* If you need to query for data then it should be part of the command encapsulating the functionality.
-```cs
-    public class CreateWidget : IAsyncHandler<CreateWidgetMessage, CommandResponse<string>>
+### Creating Handlers
+
+#### Command Handler
+
+Implement `IAsyncHandler<TRequest, TResponse>` for commands that modify state:
+
+```csharp
+public class CreateWidgetHandler : IAsyncHandler<CreateWidgetMessage, CommandResponse<string>>
+{
+    private readonly IDomainEventPublisher _publisher;
+    private readonly IWidgetRepository _repository;
+
+    public CreateWidgetHandler(
+        IDomainEventPublisher publisher,
+        IWidgetRepository repository)
     {
-        private readonly IDomainEventPublisher _publisher;
-
-        public CreateWidget(IDomainEventPublisher publisher)
-        {
-            _publisher = publisher;
-        }
-        
-        public async Task<CommandResponse<string>> Execute(
-            CreateWidgetMessage message, 
-            CancellationToken cancellationToken = default)
-        {
-            // Validate input
-            if (string.IsNullOrWhiteSpace(message?.Name))
-                return Response.Failed<string>("Widget name is required");
-
-            var response = Guid.NewGuid().ToString();
-
-            _publisher.MessageResult += (sender, eventargs) =>
-            {
-                response += $" message was sent and processed with Success={eventargs.Success}";
-            };
-
-            await _publisher.Publish(new WidgetCreated { Name = message.Name }, cancellationToken);
-
-            return Response.Ok(response);
-        }
+        _publisher = publisher;
+        _repository = repository;
     }
+    
+    public async Task<CommandResponse<string>> Execute(
+        CreateWidgetMessage message, 
+        CancellationToken cancellationToken = default)
+    {
+        // Validate input
+        if (string.IsNullOrWhiteSpace(message?.Name))
+            return Response.Failed<string>("Widget name is required");
+
+        // Create widget
+        var widgetId = Guid.NewGuid().ToString();
+        await _repository.CreateAsync(widgetId, message.Name, cancellationToken);
+
+        // Publish domain event
+        await _publisher.Publish(
+            new WidgetCreated { Id = widgetId, Name = message.Name }, 
+            cancellationToken);
+
+        return Response.Ok(widgetId);
+    }
+}
 ```
 
-## <= 1.0.3
-### Objects
-ICommandHandler
-CommandHandler
-IAsyncCommandHandler
-AsyncCommandHandler
-ICommandBroker
-CommandBroker
-IQueryHandler
-QueryHandler
-IAsyncQueryHandler
-AsyncQueryHandler
-IDomainEventPublisher
-DomainEventPublisher
-ICommandBroker
-CommandBroker
-CommandResponse
-IDomainEvent
+#### Query Handler
 
-### Basic Setup
-* Register the CommandBroker
-* Register the DomainEventPublisher
-* Define and Register the CommandHandlers
-* Define and Register the QueryHandlers
-```cs
+Implement `IAsyncHandler<TRequest, TResponse>` for queries that retrieve data:
+
+```csharp
+public class GetWidgetQuery : IAsyncHandler<GetWidget, Widget>
+{
+    private readonly IWidgetRepository _repository;
+
+    public GetWidgetQuery(IWidgetRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Widget> Execute(
+        GetWidget message, 
+        CancellationToken cancellationToken = default)
+    {
+        return await _repository.GetByIdAsync(message.Id, cancellationToken);
+    }
+}
+```
+
+#### Synchronous Handlers
+
+For synchronous operations, implement `IHandler<TRequest, TResponse>`:
+
+```csharp
+public class ValidateWidget : IHandler<Widget, bool>
+{
+    public bool Execute(Widget message)
+    {
+        return !string.IsNullOrEmpty(message.Name);
+    }
+}
+```
+
+## Domain Events
+
+Publish domain events to notify other parts of your application:
+
+```csharp
+public class CreateWidgetHandler : IAsyncHandler<CreateWidgetMessage, CommandResponse<string>>
+{
+    private readonly IDomainEventPublisher _publisher;
+
+    public CreateWidgetHandler(IDomainEventPublisher publisher)
+    {
+        _publisher = publisher;
+    }
+
+    public async Task<CommandResponse<string>> Execute(
+        CreateWidgetMessage message,
+        CancellationToken cancellationToken = default)
+    {
+        var widgetId = Guid.NewGuid().ToString();
+
+        // Publish domain event
+        await _publisher.Publish(
+            new WidgetCreated { Id = widgetId, Name = message.Name },
+            cancellationToken);
+
+        return Response.Ok(widgetId);
+    }
+}
+```
+
+### Domain Event Handlers
+
+Implement `IDomainEvent<TMessage>` to handle domain events:
+
+```csharp
+public class WidgetCreatedHandler : IDomainEvent<WidgetCreated>
+{
+    private readonly IEmailService _emailService;
+    public event EventHandler<DomainEventArgs>? OnComplete;
+
+    public WidgetCreatedHandler(IEmailService emailService)
+    {
+        _emailService = emailService;
+    }
+
+    public async Task Execute(WidgetCreated message)
+    {
+        await _emailService.SendNotificationAsync($"Widget {message.Name} created");
+        
+        OnComplete?.Invoke(this, new DomainEventArgs 
+        { 
+            Success = true, 
+            Message = "Notification sent" 
+        });
+    }
+}
+```
+
+## Pipeline Middleware (NEW in 1.0.10)
+
+Add cross-cutting concerns to domain events using middleware pipelines powered by [abes.GenericPipeline](https://github.com/tomlazelle/pipeline).
+
+### Configure Pipeline
+
+```csharp
 public void ConfigureServices(IServiceCollection services)
 {
-    services.AddSingleton<ICommandBroker, CommandBroker>();
-    service.AddTransient<IDomainEventPublisher, DomainEventPublisher>();
-    service.AddTransient<ICommandHandler<CreateMessage,CommandResponse>, CreateNewWidgetCommand>();
-    service.AddTransient<IQueryHandler<GetWidget,Widget>, GetWidgetQuery>();
+    services.AddCommandQuery(typeof(Startup).Assembly);
+    
+    // Register middleware
+    services
+        .AddDomainEventMiddleware<LoggingMiddleware<WidgetCreated>>()
+        .AddDomainEventMiddleware<ValidationMiddleware<WidgetCreated>>();
+    
+    // Configure pipeline for specific message type
+    services.AddDomainEventPipeline<WidgetCreated>(builder =>
+    {
+        builder.Use<ValidationMiddleware<WidgetCreated>>();
+        builder.Use<LoggingMiddleware<WidgetCreated>>();
+    });
 }
 ```
-### Calling a Command or Query
-Inject the ICommandBroker into your class
-Call
-```cs
-public class TestController:Controller
+
+### Create Middleware
+
+```csharp
+public class LoggingMiddleware<TMessage> : IPipelineMiddleware<DomainEventContext<TMessage>>
 {
-	private ICommandBroker _commandBroker;
+    private readonly ILogger _logger;
 
-	public TestController(ICommandBroker commandBroker)
-	{
-		_commandBroker = commandBroker;
-	}
-
-    [Route("/widget")]
-    [HttpPost]
-    public async Task<IActionResult> CreateWidget(Widget request, CancellationToken cancellationToken)
+    public LoggingMiddleware(ILogger<LoggingMiddleware<TMessage>> logger)
     {
-        // execute command
-        var result = await _commandBroker.ExecuteAsync<Widget, CommandResponse>(request, cancellationToken);
-
-        //check command result
-        if(result.Result == CommandStatus.Success)
-        {
-            // return success
-            return Ok();
-        }
-
-        // throw on failure
-        throw new BadRequestException(result.Message, result.Exception);
+        _logger = logger;
     }
-}
-```
-### Creating a Command Handler
-Command Handler is used for inserting, updating, or deleting data from your database.
-The DomainEventPublisher is used to publish an outbound message for your domain or the message could be sent to a message queue.
-Ideally commands should be encapsulated and should not call other commands or queries.
-If you need to query for data then it should be part of the command encapsulating the functionality.
-```cs
-public class WidgetCommand : AsyncCommandHandler<CreateNewWidgetMessage,CommandResponse>
-{
-    public WidgetCommand(IDomainEventPublisher) : base(domainEventPublisher)
 
-    public override async Task<CommandResponse> Execute(CreateNewWidgetMessage createNewWidgetMessage)
+    public async ValueTask InvokeAsync(
+        DomainEventContext<TMessage> context, 
+        PipelineDelegate<DomainEventContext<TMessage>> next)
     {
-        //do your work here
-
-        //publish your message accross the domain
-        DomainEventPublisher.Publish(new MessageHere());
-
-        return CommandResponse.Okay();
+        _logger.LogInformation("Processing: {MessageType}", typeof(TMessage).Name);
+        
+        await next(context); // Execute next middleware or handler
+        
+        _logger.LogInformation("Completed: {MessageType}, Success: {Success}", 
+            typeof(TMessage).Name, 
+            context.Success);
     }
 }
 ```
 
-### Create a Query Handler
-Query Handler is used for fetching data from your data source and returning a projection.
+**See [PIPELINE_GUIDE.md](PIPELINE_GUIDE.md) for comprehensive pipeline documentation.**
 
-```cs
-public class GetWidgetDataQuery:IAsyncQueryHandler<GetWidgetDataRequest, WidgetModel>
+## Response Helpers
+
+Use the static `Response` class to create command responses:
+
+```csharp
+// Success with data
+return Response.Ok(widgetId);
+
+// Success without data
+return Response.Ok();
+
+// Failure with single error
+return Response.Failed<string>("Widget not found");
+
+// Failure with multiple errors
+return Response.Failed<string>(new List<string> { "Error 1", "Error 2" });
+
+// Failure with exception
+return Response.Failed<string>(exception);
+return Response.Failed<string>("Custom message", exception);
+```
+
+## Core Interfaces
+
+### IBroker
+```csharp
+public interface IBroker
 {
-    public async Task<WidgetModel> Execute(GetWidgetDataRequest message)
-    {
-        //query for your data here
-        //do some work
-
-        return result;
-    }
+    Task<TResponse> HandleAsync<TRequest, TResponse>(
+        TRequest message, 
+        CancellationToken cancellationToken) where TRequest : IMessage;
+    
+    TResponse Handle<TRequest, TResponse>(
+        TRequest message) where TRequest : IMessage;
 }
 ```
+
+### IAsyncHandler
+```csharp
+public interface IAsyncHandler<in TRequest, TResponse> where TRequest : IMessage
+{
+    Task<TResponse> Execute(TRequest message, CancellationToken cancellationToken);
+}
+```
+
+### IHandler
+```csharp
+public interface IHandler<in TRequest, out TResponse> where TRequest : IMessage
+{
+    TResponse Execute(TRequest message);
+}
+```
+
+### IDomainEventPublisher
+```csharp
+public interface IDomainEventPublisher
+{
+    event EventHandler MessageSent;
+    event EventHandler<DomainEventArgs> MessageResult;
+    
+    Task Publish<TMessageType>(
+        TMessageType message, 
+        CancellationToken cancellationToken);
+}
+```
+
+## Best Practices
+
+✅ **Commands** - Modify state, return `CommandResponse<T>`  
+✅ **Queries** - Read-only, return domain models  
+✅ **Validation** - Validate in handlers or use pipeline middleware  
+✅ **Error Handling** - Return `Response.Failed()` instead of throwing  
+✅ **CancellationToken** - Always accept and pass cancellation tokens  
+✅ **Domain Events** - Use for cross-cutting concerns and notifications  
+✅ **Pipelines** - Add logging, validation, authorization as middleware  
+
+## Sample Application
+
+See the [sample folder](sample/) for a complete working example demonstrating:
+- Command and query handlers
+- Domain event publishing
+- Pipeline middleware
+- ASP.NET Core integration
+
+## Breaking Changes
+
+### Version 1.0.4+
+- Renamed `ICommandBroker` → `IBroker`
+- Unified command/query interfaces to `IHandler`/`IAsyncHandler`
+- Removed separate command/query base classes
+- Messages must implement `IMessage` marker interface
+
+### Version 1.0.10
+- Added pipeline middleware support via `abes.GenericPipeline`
+- Updated `Microsoft.Extensions.DependencyInjection.Abstractions` to 10.0.1
+- Enhanced error handling with detailed exception messages
+
+## License
+
+MIT License - see [LICENSE](LICENSE) file for details.
+
+## Links
+
+- [NuGet Package](https://www.nuget.org/packages/CommandQuery.Framing)
+- [GitHub Repository](https://github.com/tomlazelle/CommandQuery.Framing)
+- [Pipeline Guide](PIPELINE_GUIDE.md)
+- [Sample Application](sample/)

--- a/sample/Controllers/WidgetController.cs
+++ b/sample/Controllers/WidgetController.cs
@@ -6,26 +6,38 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace CommandQueryApiSample.Controllers
 {
-
+    /// <summary>
+    /// Controller for managing widget operations.
+    /// </summary>
     [ApiController]
     public class WidgetController : ControllerBase
     {
         private readonly IBroker _commandBroker;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WidgetController"/> class.
+        /// </summary>
+        /// <param name="commandBroker">The broker for executing commands and queries.</param>
         public WidgetController(IBroker commandBroker)
         {
             _commandBroker = commandBroker;
         }
 
+        /// <summary>
+        /// Creates a new widget.
+        /// </summary>
+        /// <param name="request">The widget creation request.</param>
+        /// <param name="cancellationToken">Cancellation token provided by ASP.NET Core.</param>
+        /// <returns>The created widget ID or error message.</returns>
         [Route("widget")]
         [HttpPost]
-        public async Task<IActionResult> Post([FromBody] CreateWidgetMessage request)
+        public async Task<IActionResult> Post(
+            [FromBody] CreateWidgetMessage request, 
+            CancellationToken cancellationToken)
         {
-
-            // create new cancellation token
-            var cancellationToken = new CancellationTokenSource().Token;
-
-            var response = await _commandBroker.HandleAsync<CreateWidgetMessage, CommandResponse<string>>(request, cancellationToken);
+            var response = await _commandBroker.HandleAsync<CreateWidgetMessage, CommandResponse<string>>(
+                request, 
+                cancellationToken);
 
             if (response.Success)
             {
@@ -35,13 +47,21 @@ namespace CommandQueryApiSample.Controllers
             return BadRequest(response.Message);
         }
 
+        /// <summary>
+        /// Gets a widget by ID.
+        /// </summary>
+        /// <param name="id">The widget ID.</param>
+        /// <param name="cancellationToken">Cancellation token provided by ASP.NET Core.</param>
+        /// <returns>The widget data.</returns>
         [Route("widget/{id}")]
         [HttpGet]
-        public async Task<IActionResult> Get(string id)
+        public async Task<IActionResult> Get(string id, CancellationToken cancellationToken)
         {
-            // create new cancellation token
-            var cancellationToken = new CancellationTokenSource().Token;
-            return Ok(await _commandBroker.HandleAsync<GetWidget, Widget>(new GetWidget { Id = id }, cancellationToken));
+            var widget = await _commandBroker.HandleAsync<GetWidget, Widget>(
+                new GetWidget { Id = id }, 
+                cancellationToken);
+            
+            return Ok(widget);
         }
     }
 }

--- a/sample/Domain/Middleware/DomainEventLoggingMiddleware.cs
+++ b/sample/Domain/Middleware/DomainEventLoggingMiddleware.cs
@@ -1,0 +1,47 @@
+using CommandQuery.Framing;
+using GenericPipeline;
+using Microsoft.Extensions.Logging;
+
+namespace CommandQueryApiSample.Domain.Middleware;
+
+/// <summary>
+/// Example middleware that logs domain event execution.
+/// Demonstrates before and after pipeline processing.
+/// </summary>
+/// <typeparam name="TMessage">The type of domain event message.</typeparam>
+public class DomainEventLoggingMiddleware<TMessage> : IPipelineMiddleware<DomainEventContext<TMessage>>
+{
+    private readonly ILogger<DomainEventLoggingMiddleware<TMessage>> _logger;
+
+    public DomainEventLoggingMiddleware(ILogger<DomainEventLoggingMiddleware<TMessage>> logger)
+    {
+        _logger = logger;
+    }
+
+    public async ValueTask InvokeAsync(
+        DomainEventContext<TMessage> context, 
+        PipelineDelegate<DomainEventContext<TMessage>> next)
+    {
+        var messageType = typeof(TMessage).Name;
+        
+        _logger.LogInformation("Before processing domain event: {MessageType}", messageType);
+        
+        try
+        {
+            await next(context);
+            
+            _logger.LogInformation(
+                "After processing domain event: {MessageType}, Success: {Success}", 
+                messageType, 
+                context.Success);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex, 
+                "Error processing domain event: {MessageType}", 
+                messageType);
+            throw;
+        }
+    }
+}

--- a/sample/Domain/Middleware/DomainEventValidationMiddleware.cs
+++ b/sample/Domain/Middleware/DomainEventValidationMiddleware.cs
@@ -1,0 +1,32 @@
+using CommandQuery.Framing;
+using GenericPipeline;
+
+namespace CommandQueryApiSample.Domain.Middleware;
+
+/// <summary>
+/// Example middleware that validates domain event messages.
+/// Can short-circuit the pipeline if validation fails.
+/// </summary>
+/// <typeparam name="TMessage">The type of domain event message.</typeparam>
+public class DomainEventValidationMiddleware<TMessage> : IPipelineMiddleware<DomainEventContext<TMessage>>
+{
+    public async ValueTask InvokeAsync(
+        DomainEventContext<TMessage> context, 
+        PipelineDelegate<DomainEventContext<TMessage>> next)
+    {
+        // Example validation - check if message is not null
+        if (context.Message == null)
+        {
+            context.Success = false;
+            context.ErrorMessage = "Domain event message cannot be null";
+            context.ShouldContinue = false;
+            return;
+        }
+
+        // Additional validation logic could go here
+        // For example, validate message properties using FluentValidation
+
+        // If validation passes, continue to next middleware/handler
+        await next(context);
+    }
+}

--- a/sample/Startup.cs
+++ b/sample/Startup.cs
@@ -1,4 +1,6 @@
 ﻿using CommandQuery.Framing;
+using CommandQueryApiSample.Domain.Messages;
+using CommandQueryApiSample.Domain.Middleware;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -20,10 +22,22 @@ namespace CommandQueryApiSample
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-
+            // Register CommandQuery framework
             services
                 .AddCommandQuery(typeof(Startup).Assembly);
             
+            // Configure domain event pipeline for WidgetCreated messages
+            // This adds middleware that runs before and after domain event handlers
+            services
+                .AddDomainEventMiddleware<DomainEventLoggingMiddleware<WidgetCreated>>()
+                .AddDomainEventMiddleware<DomainEventValidationMiddleware<WidgetCreated>>()
+                .AddDomainEventPipeline<WidgetCreated>(builder =>
+                {
+                    // Validation runs first
+                    builder.Use<DomainEventValidationMiddleware<WidgetCreated>>();
+                    // Then logging wraps the actual handler execution
+                    builder.Use<DomainEventLoggingMiddleware<WidgetCreated>>();
+                });
 
             services
                 .AddControllers()   

--- a/src/CommandQuery.Framing/Broker.cs
+++ b/src/CommandQuery.Framing/Broker.cs
@@ -5,32 +5,61 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace CommandQuery.Framing
 {
-
+    /// <summary>
+    /// Central broker for dispatching commands and queries to their registered handlers.
+    /// </summary>
     public class Broker : IBroker
     {
         private readonly IServiceProvider _serviceProvider;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Broker"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider for resolving handlers.</param>
         public Broker(IServiceProvider serviceProvider)
         {
-            _serviceProvider = serviceProvider;
+            _serviceProvider = serviceProvider ?? throw new ArgumentNullException(nameof(serviceProvider));
         }
 
-
+        /// <inheritdoc />
         public TResponse Handle<TRequest, TResponse>(TRequest message) where TRequest : IMessage
         {
+            if (message == null)
+                throw new ArgumentNullException(nameof(message));
+
             var messageHandler = _serviceProvider.GetService<IHandler<TRequest, TResponse>>();
+            
+            if (messageHandler == null)
+            {
+                throw new InvalidOperationException(
+                    $"No handler registered for request type '{typeof(TRequest).Name}' " +
+                    $"returning '{typeof(TResponse).Name}'. " +
+                    $"Ensure the handler implements IHandler<{typeof(TRequest).Name}, {typeof(TResponse).Name}> " +
+                    $"and is registered via AddCommandQuery().");
+            }
 
             var result = messageHandler.Execute(message);
-
             return result;
         }
 
+        /// <inheritdoc />
         public async Task<TResponse> HandleAsync<TRequest, TResponse>(TRequest message, CancellationToken cancellationToken = default) where TRequest : IMessage
         {
+            if (message == null)
+                throw new ArgumentNullException(nameof(message));
+
             var messageHandler = _serviceProvider.GetService<IAsyncHandler<TRequest, TResponse>>();
+            
+            if (messageHandler == null)
+            {
+                throw new InvalidOperationException(
+                    $"No handler registered for request type '{typeof(TRequest).Name}' " +
+                    $"returning '{typeof(TResponse).Name}'. " +
+                    $"Ensure the handler implements IAsyncHandler<{typeof(TRequest).Name}, {typeof(TResponse).Name}> " +
+                    $"and is registered via AddCommandQuery().");
+            }
 
             var result = await messageHandler.Execute(message, cancellationToken);
-
             return result;
         }
     }

--- a/src/CommandQuery.Framing/CommandQuery.Framing.csproj
+++ b/src/CommandQuery.Framing/CommandQuery.Framing.csproj
@@ -35,6 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="abes.GenericPipeline" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.5" />
@@ -43,7 +44,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.1" />
   </ItemGroup>
 
   <Target Name="SetNuspecProperties" BeforeTargets="GenerateNuspec">

--- a/src/CommandQuery.Framing/CommandQueryExtensions.cs
+++ b/src/CommandQuery.Framing/CommandQueryExtensions.cs
@@ -4,8 +4,23 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace CommandQuery.Framing
 {
+    /// <summary>
+    /// Extension methods for configuring CommandQuery services in dependency injection.
+    /// </summary>
     public static class CommandQueryExtensions
     {
+        /// <summary>
+        /// Adds CommandQuery framework services to the dependency injection container.
+        /// Registers the broker, domain event publisher, and scans assemblies for handlers and domain events.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection to add services to.</param>
+        /// <param name="handlers">Assemblies to scan for handlers (IHandler, IAsyncHandler) and domain events (IDomainEvent).</param>
+        /// <returns>The service collection for chaining.</returns>
+        /// <example>
+        /// <code>
+        /// services.AddCommandQuery(typeof(Startup).Assembly);
+        /// </code>
+        /// </example>
         public static IServiceCollection AddCommandQuery(this IServiceCollection serviceCollection, params Assembly[] handlers)
         {
 

--- a/src/CommandQuery.Framing/CommandResponse.cs
+++ b/src/CommandQuery.Framing/CommandResponse.cs
@@ -2,16 +2,30 @@
 
 namespace CommandQuery.Framing
 {
+    /// <summary>
+    /// Represents the response from executing a command or query.
+    /// </summary>
+    /// <typeparam name="T">The type of data returned in the response.</typeparam>
     public class CommandResponse<T>
     {
-
+        /// <summary>
+        /// Gets or sets a value indicating whether the operation was successful.
+        /// </summary>
         public bool Success { get; set; }
 
+        /// <summary>
+        /// Gets or sets the response data.
+        /// </summary>
         public T Data { get; set; }
 
+        /// <summary>
+        /// Gets or sets a message describing the result (typically used for errors).
+        /// </summary>
         public string Message { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the exception that occurred, if any.
+        /// </summary>
         public Exception Exception { get; set; }
-
-
     }
 }

--- a/src/CommandQuery.Framing/DomainEventContext.cs
+++ b/src/CommandQuery.Framing/DomainEventContext.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Threading;
+using GenericPipeline;
+
+namespace CommandQuery.Framing;
+
+/// <summary>
+/// Context for domain event pipeline execution.
+/// Contains the message and allows middleware to access and modify execution state.
+/// </summary>
+/// <typeparam name="TMessage">The type of message being published.</typeparam>
+public class DomainEventContext<TMessage> : PipelineContext
+{
+    /// <summary>
+    /// Gets or sets the message being published to domain event handlers.
+    /// </summary>
+    public TMessage Message { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the domain event processing should continue.
+    /// Set to false in middleware to short-circuit the pipeline.
+    /// </summary>
+    public bool ShouldContinue { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the domain event was processed successfully.
+    /// </summary>
+    public bool Success { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets an error message if processing failed.
+    /// </summary>
+    public string ErrorMessage { get; set; }
+
+    /// <summary>
+    /// Gets or sets an exception that occurred during processing.
+    /// </summary>
+    public Exception Exception { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DomainEventContext{TMessage}"/> class.
+    /// </summary>
+    /// <param name="message">The message to publish.</param>
+    /// <param name="cancellationToken">Cancellation token for the operation.</param>
+    public DomainEventContext(TMessage message, CancellationToken cancellationToken = default)
+    {
+        Message = message;
+        CancellationToken = cancellationToken;
+    }
+}

--- a/src/CommandQuery.Framing/DomainEventPipelineExtensions.cs
+++ b/src/CommandQuery.Framing/DomainEventPipelineExtensions.cs
@@ -1,0 +1,57 @@
+using System;
+using GenericPipeline;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace CommandQuery.Framing;
+
+/// <summary>
+/// Extension methods for configuring domain event pipelines with before and after middleware.
+/// </summary>
+public static class DomainEventPipelineExtensions
+{
+    /// <summary>
+    /// Adds a domain event pipeline with before and after middleware for a specific message type.
+    /// </summary>
+    /// <typeparam name="TMessage">The type of message this pipeline handles.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <param name="configurePipeline">Action to configure the pipeline with middleware.</param>
+    /// <returns>The service collection for chaining.</returns>
+    /// <example>
+    /// <code>
+    /// services.AddDomainEventPipeline&lt;WidgetCreated&gt;(builder =&gt;
+    /// {
+    ///     builder.Use&lt;LoggingMiddleware&lt;DomainEventContext&lt;WidgetCreated&gt;&gt;&gt;();
+    ///     builder.Use&lt;ValidationMiddleware&lt;DomainEventContext&lt;WidgetCreated&gt;&gt;&gt;();
+    /// });
+    /// </code>
+    /// </example>
+    public static IServiceCollection AddDomainEventPipeline<TMessage>(
+        this IServiceCollection services,
+        Action<PipelineBuilder<DomainEventContext<TMessage>>> configurePipeline)
+    {
+        services.AddSingleton<PipelineDelegate<DomainEventContext<TMessage>>>(sp =>
+        {
+            var builder = new PipelineBuilder<DomainEventContext<TMessage>>();
+            configurePipeline(builder);
+            
+            var diagnostics = sp.GetService<IPipelineDiagnostics<DomainEventContext<TMessage>>>();
+            return builder.Build(diagnostics);
+        });
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds a scoped middleware type for use in domain event pipelines.
+    /// </summary>
+    /// <typeparam name="TMiddleware">The middleware type to register.</typeparam>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection for chaining.</returns>
+    public static IServiceCollection AddDomainEventMiddleware<TMiddleware>(
+        this IServiceCollection services)
+        where TMiddleware : class
+    {
+        services.AddScoped<TMiddleware>();
+        return services;
+    }
+}

--- a/src/CommandQuery.Framing/DomainEventPublisher.cs
+++ b/src/CommandQuery.Framing/DomainEventPublisher.cs
@@ -1,31 +1,89 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using GenericPipeline;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace CommandQuery.Framing
 {
+    /// <summary>
+    /// Publisher for domain events with support for pipeline middleware.
+    /// Executes before and after pipelines around domain event handlers.
+    /// </summary>
     public class DomainEventPublisher : IDomainEventPublisher
     {
         public event EventHandler MessageSent;
         public event EventHandler<DomainEventArgs> MessageResult;
 
         private readonly IServiceProvider _serviceProvider;
+        private readonly IServiceScopeFactory _scopeFactory;
 
-        public DomainEventPublisher(IServiceProvider serviceProvider)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DomainEventPublisher"/> class.
+        /// </summary>
+        /// <param name="serviceProvider">The service provider for resolving dependencies.</param>
+        /// <param name="scopeFactory">The scope factory for creating DI scopes for pipeline execution.</param>
+        public DomainEventPublisher(IServiceProvider serviceProvider, IServiceScopeFactory scopeFactory)
         {
             _serviceProvider = serviceProvider;
+            _scopeFactory = scopeFactory;
         }
 
+        /// <inheritdoc />
         public async Task Publish<TMessageType>(TMessageType message, CancellationToken cancellationToken = default)
         {
+            var context = new DomainEventContext<TMessageType>(message, cancellationToken);
+
+            // Execute before pipeline if configured
+            var beforePipeline = _serviceProvider.GetService<PipelineDelegate<DomainEventContext<TMessageType>>>();
+            if (beforePipeline != null)
+            {
+                using var scope = _scopeFactory.CreateScope();
+                context.Items["__GenericPipeline_ServiceProvider"] = scope.ServiceProvider;
+                await beforePipeline(context);
+
+                // Check if pipeline indicated we should stop
+                if (!context.ShouldContinue)
+                {
+                    return;
+                }
+            }
+
+            // Execute domain event handlers
             var events = _serviceProvider.GetServices<IDomainEvent<TMessageType>>();
 
             foreach (var domainEvent in events)
             {
+                if (!context.ShouldContinue)
+                    break;
+
                 domainEvent.OnComplete += DomainEvent_OnComplete;
-                MessageSent?.Invoke(this, new DomainEventArgs());
-                await domainEvent.Execute(message);
+                
+                try
+                {
+                    MessageSent?.Invoke(this, new DomainEventArgs());
+                    await domainEvent.Execute(message);
+                }
+                catch (Exception ex)
+                {
+                    context.Success = false;
+                    context.Exception = ex;
+                    context.ErrorMessage = ex.Message;
+                    throw;
+                }
+                finally
+                {
+                    domainEvent.OnComplete -= DomainEvent_OnComplete;
+                }
+            }
+
+            // Execute after pipeline if configured
+            var afterPipeline = _serviceProvider.GetService<PipelineDelegate<DomainEventContext<TMessageType>>>();
+            if (afterPipeline != null && beforePipeline != null) // Only run after if before was configured
+            {
+                using var scope = _scopeFactory.CreateScope();
+                context.Items["__GenericPipeline_ServiceProvider"] = scope.ServiceProvider;
+                await afterPipeline(context);
             }
         }
 

--- a/src/CommandQuery.Framing/IAsyncHandler.cs
+++ b/src/CommandQuery.Framing/IAsyncHandler.cs
@@ -4,12 +4,18 @@ using System.Threading.Tasks;
 namespace CommandQuery.Framing
 {
     /// <summary>
-    /// Asynchronous request handler
+    /// Asynchronous request handler for processing commands and queries.
     /// </summary>
-    /// <typeparam name="TRequest">The type of the request.</typeparam>
+    /// <typeparam name="TRequest">The type of the request message.</typeparam>
     /// <typeparam name="TResponse">The type of the response.</typeparam>
     public interface IAsyncHandler<in TRequest, TResponse> where TRequest : IMessage
     {
+        /// <summary>
+        /// Executes the handler asynchronously for the given request message.
+        /// </summary>
+        /// <param name="message">The request message to process.</param>
+        /// <param name="cancellationToken">A cancellation token that can be used to cancel the work.</param>
+        /// <returns>A task representing the asynchronous operation, containing the response.</returns>
         Task<TResponse> Execute(TRequest message, CancellationToken cancellationToken);
     }
 }

--- a/src/CommandQuery.Framing/IBroker.cs
+++ b/src/CommandQuery.Framing/IBroker.cs
@@ -3,9 +3,32 @@ using System.Threading.Tasks;
 
 namespace CommandQuery.Framing
 {
+    /// <summary>
+    /// Central broker for dispatching commands and queries to their registered handlers.
+    /// </summary>
     public interface IBroker
     {
+        /// <summary>
+        /// Asynchronously executes a handler for the given request message.
+        /// </summary>
+        /// <typeparam name="TRequest">The type of request message implementing <see cref="IMessage"/>.</typeparam>
+        /// <typeparam name="TResponse">The type of response returned by the handler.</typeparam>
+        /// <param name="message">The request message to handle. Cannot be null.</param>
+        /// <param name="cancellationToken">Optional token to cancel the operation.</param>
+        /// <returns>The response from the handler.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when message is null.</exception>
+        /// <exception cref="System.InvalidOperationException">Thrown when no handler is registered for the request type.</exception>
         Task<TResponse> HandleAsync<TRequest, TResponse>(TRequest message, CancellationToken cancellationToken) where TRequest : IMessage;
+        
+        /// <summary>
+        /// Synchronously executes a handler for the given request message.
+        /// </summary>
+        /// <typeparam name="TRequest">The type of request message implementing <see cref="IMessage"/>.</typeparam>
+        /// <typeparam name="TResponse">The type of response returned by the handler.</typeparam>
+        /// <param name="message">The request message to handle. Cannot be null.</param>
+        /// <returns>The response from the handler.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown when message is null.</exception>
+        /// <exception cref="System.InvalidOperationException">Thrown when no handler is registered for the request type.</exception>
         TResponse Handle<TRequest, TResponse>(TRequest message) where TRequest : IMessage;
     }
 }

--- a/src/CommandQuery.Framing/IDomainEvent.cs
+++ b/src/CommandQuery.Framing/IDomainEvent.cs
@@ -3,15 +3,38 @@ using System.Threading.Tasks;
 
 namespace CommandQuery.Framing
 {
+    /// <summary>
+    /// Represents a domain event handler that processes messages of a specific type.
+    /// </summary>
+    /// <typeparam name="T">The type of message this domain event handles.</typeparam>
     public interface IDomainEvent<in T>
     {
+        /// <summary>
+        /// Event raised when the domain event execution completes.
+        /// </summary>
         event EventHandler<DomainEventArgs>? OnComplete;
+        
+        /// <summary>
+        /// Executes the domain event handler for the given message.
+        /// </summary>
+        /// <param name="message">The message to process.</param>
+        /// <returns>A task representing the asynchronous operation.</returns>
         Task Execute(T message);
     }
 
+    /// <summary>
+    /// Event arguments for domain event completion notifications.
+    /// </summary>
     public class DomainEventArgs : EventArgs
     {
+        /// <summary>
+        /// Gets or sets a value indicating whether the domain event was processed successfully.
+        /// </summary>
         public bool Success { get; set; }
+        
+        /// <summary>
+        /// Gets or sets a message describing the result of the domain event execution.
+        /// </summary>
         public string Message { get; set; }
     }
 }

--- a/src/CommandQuery.Framing/IDomainEventPublisher.cs
+++ b/src/CommandQuery.Framing/IDomainEventPublisher.cs
@@ -4,9 +4,27 @@ using System.Threading.Tasks;
 
 namespace CommandQuery.Framing;
 
+/// <summary>
+/// Publisher for domain events that notifies registered handlers.
+/// </summary>
 public interface IDomainEventPublisher
 {
+    /// <summary>
+    /// Event raised when a message is sent to domain event handlers.
+    /// </summary>
     event EventHandler MessageSent;
+    
+    /// <summary>
+    /// Event raised when domain event handlers complete processing.
+    /// </summary>
     event EventHandler<DomainEventArgs> MessageResult;
+    
+    /// <summary>
+    /// Publishes a message to all registered domain event handlers.
+    /// </summary>
+    /// <typeparam name="TMessageType">The type of message to publish.</typeparam>
+    /// <param name="message">The message to publish to domain event handlers.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the operation.</param>
+    /// <returns>A task representing the asynchronous publish operation.</returns>
     Task Publish<TMessageType>(TMessageType message, CancellationToken cancellationToken);
 }

--- a/src/CommandQuery.Framing/IHandler.cs
+++ b/src/CommandQuery.Framing/IHandler.cs
@@ -1,12 +1,17 @@
 ﻿namespace CommandQuery.Framing
 {
     /// <summary>
-    /// Synchronous request handler
+    /// Synchronous request handler for processing commands and queries.
     /// </summary>
-    /// <typeparam name="TRequest">The type of the request.</typeparam>
+    /// <typeparam name="TRequest">The type of the request message.</typeparam>
     /// <typeparam name="TResponse">The type of the response.</typeparam>
     public interface IHandler<in TRequest, out TResponse> where TRequest : IMessage
     {
+        /// <summary>
+        /// Executes the handler synchronously for the given request message.
+        /// </summary>
+        /// <param name="message">The request message to process.</param>
+        /// <returns>The response from executing the handler.</returns>
         TResponse Execute(TRequest message);
     }
 }

--- a/src/CommandQuery.Framing/IMessage.cs
+++ b/src/CommandQuery.Framing/IMessage.cs
@@ -1,6 +1,10 @@
 ﻿
 namespace CommandQuery.Framing
 {
+    /// <summary>
+    /// Marker interface for all command and query messages.
+    /// Implement this interface on your request/message types to use them with the broker.
+    /// </summary>
     public interface IMessage
     {
 

--- a/src/CommandQuery.Framing/Response.cs
+++ b/src/CommandQuery.Framing/Response.cs
@@ -3,8 +3,18 @@ using System.Collections.Generic;
 
 namespace CommandQuery.Framing
 {
+    /// <summary>
+    /// Static helper class for creating command responses.
+    /// </summary>
     public static class Response
     {
+        /// <summary>
+        /// Creates a failed response with multiple error messages.
+        /// </summary>
+        /// <typeparam name="T">The type of data in the response.</typeparam>
+        /// <param name="errorMessages">The list of error messages.</param>
+        /// <param name="exception">Optional exception that caused the failure.</param>
+        /// <returns>A failed command response.</returns>
         public static CommandResponse<T> Failed<T>(List<string> errorMessages, Exception exception = null)
         {
             return new CommandResponse<T>
@@ -15,6 +25,45 @@ namespace CommandQuery.Framing
                    };
         }
 
+        /// <summary>
+        /// Creates a failed response with a single error message.
+        /// </summary>
+        /// <typeparam name="T">The type of data in the response.</typeparam>
+        /// <param name="errorMessage">The error message.</param>
+        /// <param name="exception">Optional exception that caused the failure.</param>
+        /// <returns>A failed command response.</returns>
+        public static CommandResponse<T> Failed<T>(string errorMessage, Exception exception = null)
+        {
+            return new CommandResponse<T>
+                   {
+                       Success = false,
+                       Message = errorMessage,
+                       Exception = exception
+                   };
+        }
+
+        /// <summary>
+        /// Creates a failed response from an exception.
+        /// </summary>
+        /// <typeparam name="T">The type of data in the response.</typeparam>
+        /// <param name="exception">The exception that caused the failure.</param>
+        /// <returns>A failed command response with the exception message.</returns>
+        public static CommandResponse<T> Failed<T>(Exception exception)
+        {
+            return new CommandResponse<T>
+                   {
+                       Success = false,
+                       Message = exception?.Message ?? "An error occurred",
+                       Exception = exception
+                   };
+        }
+
+        /// <summary>
+        /// Creates a successful response with data.
+        /// </summary>
+        /// <typeparam name="T">The type of data in the response.</typeparam>
+        /// <param name="data">The response data.</param>
+        /// <returns>A successful command response.</returns>
         public static CommandResponse<T> Ok<T>(T data)
         {
             return new CommandResponse<T>
@@ -24,6 +73,16 @@ namespace CommandQuery.Framing
                    };
         }
 
-
+        /// <summary>
+        /// Creates a successful response without data.
+        /// </summary>
+        /// <returns>A successful command response.</returns>
+        public static CommandResponse<object> Ok()
+        {
+            return new CommandResponse<object>
+                   {
+                       Success = true
+                   };
+        }
     }
 }


### PR DESCRIPTION
Adds pipeline support to domain events.

This change introduces the ability to define before and after pipelines for domain events, allowing cross-cutting concerns to be easily integrated.

- Introduces `abes.GenericPipeline` for middleware support.
- Adds extension methods for configuring domain event pipelines.
- Updates the `DomainEventPublisher` to execute pipelines.