### PR TITLE
Enhances command registration with logging and validation

### DIFF
--- a/src/CommandQuery.Framing/CommandQueryExtensions.cs
+++ b/src/CommandQuery.Framing/CommandQueryExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Linq;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace CommandQuery.Framing
 {
@@ -37,5 +39,153 @@ namespace CommandQuery.Framing
 
             return serviceCollection;
         }
+
+        /// <summary>
+        /// Adds CommandQuery framework services to the dependency injection container with optional configuration.
+        /// Registers the broker, domain event publisher, and scans assemblies for handlers and domain events.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection to add services to.</param>
+        /// <param name="options">Configuration options for registration behavior.</param>
+        /// <param name="handlers">Assemblies to scan for handlers (IHandler, IAsyncHandler) and domain events (IDomainEvent).</param>
+        /// <returns>The service collection for chaining.</returns>
+        /// <example>
+        /// <code>
+        /// services.AddCommandQuery(new CommandQueryOptions 
+        /// { 
+        ///     LogRegistrations = true, 
+        ///     ValidateRegistrations = true 
+        /// }, typeof(Startup).Assembly);
+        /// </code>
+        /// </example>
+        public static IServiceCollection AddCommandQuery(
+            this IServiceCollection serviceCollection, 
+            CommandQueryOptions options,
+            params Assembly[] handlers)
+        {
+            if (options == null)
+                throw new ArgumentNullException(nameof(options));
+
+            serviceCollection.AddSingleton<IBroker, Broker>();
+            serviceCollection.AddSingleton<IDomainEventPublisher, DomainEventPublisher>();
+
+            var targetTypes = new Type[]
+            {
+                typeof(IAsyncHandler<,>),
+                typeof(IHandler<,>),
+                typeof(IDomainEvent<>)
+            };
+
+            serviceCollection.ScanAndAddTransientTypesWithTracking(
+                handlers,
+                targetTypes,
+                out var registrationInfo);
+
+            // Feature 1: Log all registered handlers and domain events
+            if (options.LogRegistrations)
+            {
+                LogRegistrations(registrationInfo, targetTypes);
+            }
+
+            // Feature 2: Validate all handlers in the assemblies were registered
+            if (options.ValidateRegistrations)
+            {
+                ValidateRegistrations(handlers, registrationInfo, targetTypes);
+            }
+
+            return serviceCollection;
+        }
+
+        private static void LogRegistrations(RegistrationInfo registrationInfo, Type[] targetTypes)
+        {
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+                builder.SetMinimumLevel(LogLevel.Information);
+            });
+
+            var logger = loggerFactory.CreateLogger("CommandQuery.Framing.Registration");
+
+            logger.LogInformation("=== CommandQuery Registration Summary ===");
+            logger.LogInformation("Total implementation types found: {Count}", registrationInfo.ImplementationTypes.Count);
+
+            // Group by target type (IAsyncHandler, IHandler, IDomainEvent)
+            foreach (var targetType in targetTypes)
+            {
+                var matchingTypes = registrationInfo.ImplementationTypes
+                    .Where(t => t.GetInterfaces()
+                        .Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == targetType))
+                    .ToList();
+
+                if (matchingTypes.Any())
+                {
+                    var typeName = targetType.Name;
+                    logger.LogInformation("--- {TypeName} ({Count}) ---", typeName, matchingTypes.Count);
+                    
+                    foreach (var implType in matchingTypes.OrderBy(t => t.FullName))
+                    {
+                        logger.LogInformation("  → {TypeName}", implType.FullName);
+                    }
+                }
+            }
+
+            logger.LogInformation("=== End Registration Summary ===");
+        }
+
+        private static void ValidateRegistrations(
+            Assembly[] assemblies, 
+            RegistrationInfo registrationInfo,
+            Type[] targetTypes)
+        {
+            var loggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddConsole();
+                builder.SetMinimumLevel(LogLevel.Warning);
+            });
+
+            var logger = loggerFactory.CreateLogger("CommandQuery.Framing.Validation");
+
+            // Find all types in the assemblies that implement the target interfaces
+            var allHandlerTypes = assemblies
+                .SelectMany(a =>
+                {
+                    try
+                    {
+                        return a.GetTypes();
+                    }
+                    catch (ReflectionTypeLoadException ex)
+                    {
+                        return ex.Types.Where(t => t != null);
+                    }
+                })
+                .Where(t => !t.IsAbstract && !t.IsInterface)
+                .Where(t => targetTypes.Any(targetType =>
+                    t.GetInterfaces().Any(i =>
+                        i.IsGenericType && i.GetGenericTypeDefinition() == targetType)))
+                .ToList();
+
+            var registeredTypes = registrationInfo.ImplementationTypes.ToHashSet();
+            var unregisteredTypes = allHandlerTypes.Where(t => !registeredTypes.Contains(t)).ToList();
+
+            if (unregisteredTypes.Any())
+            {
+                logger.LogError("=== Validation Failed: Unregistered Handlers Found ===");
+                foreach (var type in unregisteredTypes)
+                {
+                    logger.LogError("  ✗ {TypeName} was not registered", type.FullName);
+                }
+                logger.LogError("=== End Validation ===");
+
+                throw new InvalidOperationException(
+                    $"Validation failed: {unregisteredTypes.Count} handler(s) were not registered. " +
+                    $"Types: {string.Join(", ", unregisteredTypes.Select(t => t.Name))}");
+            }
+            else
+            {
+                logger.LogInformation("=== Validation Passed ===");
+                logger.LogInformation("All {Count} handler types in the assemblies were successfully registered.", allHandlerTypes.Count);
+                logger.LogInformation("=== End Validation ===");
+            }
+        }
+
     }
 }

--- a/src/CommandQuery.Framing/CommandQueryOptions.cs
+++ b/src/CommandQuery.Framing/CommandQueryOptions.cs
@@ -1,0 +1,21 @@
+namespace CommandQuery.Framing
+{
+    /// <summary>
+    /// Configuration options for CommandQuery framework registration.
+    /// </summary>
+    public class CommandQueryOptions
+    {
+        /// <summary>
+        /// When true, logs all registered handlers and domain events to the console.
+        /// Default is false.
+        /// </summary>
+        public bool LogRegistrations { get; set; }
+
+        /// <summary>
+        /// When true, validates that all handler types in the scanned assemblies 
+        /// have been successfully registered and throws an exception if any are missing.
+        /// Default is false.
+        /// </summary>
+        public bool ValidateRegistrations { get; set; }
+    }
+}

--- a/src/CommandQuery.Framing/TypeExtensions.cs
+++ b/src/CommandQuery.Framing/TypeExtensions.cs
@@ -1,11 +1,21 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
 namespace CommandQuery.Framing
 {
+    /// <summary>
+    /// Tracks types registered during assembly scanning.
+    /// </summary>
+    internal class RegistrationInfo
+    {
+        public List<Type> ImplementationTypes { get; } = new List<Type>();
+        public List<(Type ServiceType, Type ImplementationType)> Registrations { get; } = new List<(Type, Type)>();
+    }
+
     /// <summary>
     /// type extensions
     /// </summary>
@@ -22,6 +32,25 @@ namespace CommandQuery.Framing
             Assembly[] assemblies,
             Type[] types)
         {
+            ScanAndAddTransientTypesWithTracking(serviceCollection, assemblies, types, out _);
+            return serviceCollection;
+        }
+
+        /// <summary>
+        /// Scans and adds transient types, returning tracking information about what was registered.
+        /// </summary>
+        /// <param name="serviceCollection">The service collection.</param>
+        /// <param name="assemblies">The assemblies.</param>
+        /// <param name="types">The types.</param>
+        /// <param name="registrationInfo">Output parameter containing registration tracking information.</param>
+        public static IServiceCollection ScanAndAddTransientTypesWithTracking(
+            this IServiceCollection serviceCollection,
+            Assembly[] assemblies,
+            Type[] types,
+            out RegistrationInfo registrationInfo)
+        {
+            var info = new RegistrationInfo();
+            
             var loggerFactory = LoggerFactory.Create(builder =>
             {
                 builder.AddConsole();
@@ -35,6 +64,8 @@ namespace CommandQuery.Framing
                 .Matches(types)
                 .Do(implementationType =>
                 {
+                    info.ImplementationTypes.Add(implementationType);
+                    
                     var serviceTypes = implementationType.GetTypeInfo()
                         .ImplementedInterfaces
                         .ToList();
@@ -45,12 +76,15 @@ namespace CommandQuery.Framing
                     foreach (var serviceType in serviceTypes.Distinct())
                     {
                         serviceCollection.AddTransient(serviceType, implementationType);
+                        info.Registrations.Add((serviceType, implementationType));
                     }
                 })
                 .Execute();
 
+            registrationInfo = info;
             return serviceCollection;
         }
+
 
     }
 }


### PR DESCRIPTION
Adds optional logging and validation for command handler registrations. Introduces `CommandQueryOptions` for configurable behavior. Ensures all handlers are correctly logged and validated by adding new methods for registration tracking.

Branch: adding-scan-options